### PR TITLE
Import Makefile from Kubernetes Master, Adds release target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *~
 *\#*
 /files/.kubernetes-*
+.venv

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+
+build: virtualenv lint test
+
+virtualenv:
+	virtualenv .venv
+	.venv/bin/pip install -q -r requirements.txt
+
+lint: virtualenv
+	@.venv/bin/flake8 hooks unit_tests --exclude=charmhelpers
+	@.venv/bin/charm proof
+
+test: virtualenv 
+	@CHARM_DIR=. PYTHONPATH=./hooks .venv/bin/py.test unit_tests/*
+
+functional-test:
+	@bundletester
+
+release: check-path
+	@.venv/bin/pip install git-vendor
+	@.venv/bin/git-vendor sync -d $KUBERNETES_BZR
+
+check-path:
+ifndef KUBERNETES_BZR
+	$(error KUBERNETES_BZR is undefined)
+endif
+
+clean:
+	rm -rf .venv
+	find -name *.pyc -delete

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flake8
+pytest
+bundletester
+path.py


### PR DESCRIPTION
`check-path` will sniff the ENV for $KUBERNETES_MASTER_BZR envvar. If it
is not found, it will not allow the release process to continue.

`make release` will kick off the release process of installing the
git-vendor python module, and passing off the $KUBERNETES_MASTER_BZR env
location to git-vendor. _note_ the constraints of git-vendor still
apply. The repository must have a tag to export and cannot be in a dirty
state.

This is CI-capable so long as CI doesn't alter any files in the
repository prior to "blessing" a release. At which point, we can
automate the release process by setting the ENVVAR for the job.
