### PR TITLE
Refactoring to satisfy lint target, and test target

### DIFF
--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -165,7 +165,7 @@ def register_machine(apiserver, retry=False):
     parsed = urlparse.urlparse(apiserver)
     headers = {"Content-type": "application/json",
                "Accept": "application/json"}
-    #identity = hookenv.local_unit().replace('/', '-')
+    # identity = hookenv.local_unit().replace('/', '-')
     private_address = hookenv.unit_private_ip()
 
     with open('/proc/meminfo') as fh:
@@ -219,7 +219,7 @@ def setup_kubernetes_group():
     output = subprocess.check_output(['groups', 'kubernetes'])
 
     # TODO: check group exists
-    if not 'docker' in output:
+    if 'docker' not in output:
         subprocess.check_output(
             ['usermod', '-a', '-G', 'docker', 'kubernetes'])
 

--- a/hooks/kubernetes_installer.py
+++ b/hooks/kubernetes_installer.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import subprocess
 from path import path
 
@@ -29,7 +28,8 @@ class KubernetesInstaller():
         output_dir.makedirs()
 
         # Write the version and arch to a dot file.
-        (output_dir / '.kubernetes').write_text('{0} {1}'.format(self.version, self.arch))
+        (output_dir / '.kubernetes').write_text('{0} {1}'.format(self.version,
+                                                                 self.arch))
 
         if self.kubernetes_file.exists():
             # Untar the file to the output directory.

--- a/unit_tests/test_hooks.py
+++ b/unit_tests/test_hooks.py
@@ -1,0 +1,8 @@
+# import pytest
+
+
+class TestHooks():
+
+    # TODO: Actually write tests.
+    def test_fake(self):
+        pass


### PR DESCRIPTION
The imported test target in the makefile did not have actual tests. This
introduces a WIP todo item for adding unit_tests to the charm to test
the hooks.py code.

Additional cleanup of syntactic sugar to satisfy the lint target.
