### PR TITLE
Adding double tack to the upstart templates.

### DIFF
--- a/files/kubelet.upstart.tmpl
+++ b/files/kubelet.upstart.tmpl
@@ -8,7 +8,7 @@ limit nofile 20000 20000
 kill timeout 60 # wait 60s between SIGTERM and SIGKILL.
 
 exec /usr/local/bin/kubelet \
-     -address=%(kubelet_bind_addr)s \
-     -etcd_servers=%(etcd_servers)s \
-     -hostname_override=%(kubelet_bind_addr)s \
-     -logtostderr=true
+     --address=%(kubelet_bind_addr)s \
+     --etcd_servers=%(etcd_servers)s \
+     --hostname_override=%(kubelet_bind_addr)s \
+     --logtostderr=true

--- a/files/proxy.upstart.tmpl
+++ b/files/proxy.upstart.tmpl
@@ -8,6 +8,6 @@ limit nofile 20000 20000
 kill timeout 60 # wait 60s between SIGTERM and SIGKILL.
 
 exec /usr/local/bin/proxy \
-     -etcd_servers=%(etcd_servers)s \
-     -master=%(kubeapi_server)s \
-     -logtostderr=true
+     --etcd_servers=%(etcd_servers)s \
+     --master=%(kubeapi_server)s \
+     --logtostderr=true


### PR DESCRIPTION
Testing revealed that the old upstart templates do not work with current versions of kubernetes. We found the older docs listed these arguments with single tack (-) and that was likely the reason the original upstart scripts had arguments with single tacks.

I added double tack arguments tot he upstart scripts and deployed kubernetes v0.8.1 (our default version) and everything worked, so this pull request is suggesting we move to using double tacks everywhere as not to break current versions of kubernetes.
