### PR TITLE
Api response codes

### DIFF
--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -216,11 +216,11 @@ def register_machine(apiserver, retry=False):
     if response.status in (200, 201):
         print("Registered")
     elif response.status in (409,):
-        print("Status conflict!")
+        print("Status conflict")
         # The kubernetes API documentation suggests doing a put in this case:
         # issue a PUT/update to modify the existing object
         conn.request("PUT", "/api/v1beta1/minions", json.dumps(request),
-            headers)
+                     headers)
     elif not retry and response.status in (500,) and result.get(
             'message', '').startswith('The requested resource does not exist'):
         # There's something fishy in the kube api here (0.4 dev), first time we


### PR DESCRIPTION
- Moved the original request to one-line because it fits under 80 characters.
- Added 201 to the successful response codes.
- Moved 409 to its own branch, because that indicates a status conflict, and PUT should be used instead.
