### PR TITLE
Subordinate conversion

### DIFF
--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -67,7 +67,7 @@ def relation_changed():
     template_data = get_template_data()
 
     # Check required keys
-    for k in ('etcd_servers', 'kubeapi_server', 'overlay_type'):
+    for k in ('etcd_servers', 'kubeapi_server'):
         if not template_data.get(k):
             print("Missing data for %s %s" % (k, template_data))
             return

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,6 +10,7 @@ description: |
 tags:
     - ops
     - network
+subordinate: true
 requires:
   etcd:
     interface: etcd
@@ -17,3 +18,6 @@ requires:
     interface: kubernetes-api
   network:
     interface: overlay-network
+  docker-host:
+    interface: juju-info
+    scope: container


### PR DESCRIPTION
This branch has been tested repeatedly, and I have confidence this is ready for merging. 

This is a significant change: it converts the Kubernetes charm to a subordinate, intended to be colocated with a docker/flannel-docker host charm. 
