### PR TITLE
Api changes

### DIFF
--- a/files/kubelet.upstart.tmpl
+++ b/files/kubelet.upstart.tmpl
@@ -9,6 +9,6 @@ kill timeout 60 # wait 60s between SIGTERM and SIGKILL.
 
 exec /usr/local/bin/kubelet \
      --address=%(kubelet_bind_addr)s \
-     --etcd_servers=%(etcd_servers)s \
+     --api_servers=%(kubeapi_server)s \
      --hostname_override=%(kubelet_bind_addr)s \
      --logtostderr=true

--- a/files/proxy.upstart.tmpl
+++ b/files/proxy.upstart.tmpl
@@ -8,6 +8,5 @@ limit nofile 20000 20000
 kill timeout 60 # wait 60s between SIGTERM and SIGKILL.
 
 exec /usr/local/bin/proxy \
-     --etcd_servers=%(etcd_servers)s \
      --master=%(kubeapi_server)s \
      --logtostderr=true

--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -189,36 +189,33 @@ def register_machine(apiserver, retry=False):
         mem = info.strip().split(":")[1].strip().split()[0]
     cpus = os.sysconf("SC_NPROCESSORS_ONLN")
 
+    # This is the v1beta3 api json object that registers nodes.
     request = _encode(
         {
-            'Kind': 'Minion',
-            # These can only differ for cloud provider backed instances?
-            'ID': private_address,
-            'HostIP': private_address,
-            'metadata': {
-                'name': private_address,
-            },
-            'resources': {
-                'capacity': {
-                    'mem': mem + ' K',
-                    'cpu': cpus
-                }
-            },
-            'status': {
-                'Capacity': {
-                    'mem': mem + ' K',
-                    'cpu': cpus
-                }
-            },
-            'spec': {
-                'ExternalID': private_address,
+          "creationTimestamp": "",
+          "kind": "Minion",
+          "name": private_address,
+          "metadata": {
+            "name": private_address,
+          },
+          "spec": {
+            "externalID": private_address,
+            "capacity": {
+                "mem": mem + " K",
+                "cpu": cpus
             }
+          },
+          "status": {
+            "conditions": [],
+            "hostIP": private_address,
+          }
         }
-    )
+     )
+
 
     print("Registration request %s" % request)
     conn = httplib.HTTPConnection(parsed.hostname, parsed.port)
-    conn.request("POST", "/api/v1beta1/minions", json.dumps(request), headers)
+    conn.request("POST", "/api/v1beta3/nodes", json.dumps(request), headers)
 
     response = conn.getresponse()
     body = response.read()


### PR DESCRIPTION
I made some api changes here to register nodes with the v1beta3 api.

THIS CODE DOES NOT HAVE TESTS!  So this code should be used as a **temporary** solution until the code effort with tests lands. 

Furthermore, I found that starting in v0.15.0 of kubernetes the kubelet and kube-proxy commands stop accepting the etcd_servers flag.  So this change attempts to fix those problems so the services stay running on a kubernetes node.
